### PR TITLE
Add CancelAsyncCommand to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ To run the application, press `F5` or select `Debug > Start Debugging` from the 
 
 - `SendPromptAsyncCommand`: Command to send a chat prompt.
 - `SendPromptStreamAsyncCommand`: Command to send a chat prompt with streaming response.
+- `CancelAsyncCommand`: Command to send a chat prompt.
 - `SaveConversationAsyncCommand`: Command to save the conversation.
 - `ClearConversationAsyncCommand`: Command to clear the conversation.
 - `LoadConversationAsyncCommand`: Command to load a conversation.


### PR DESCRIPTION
Add CancelAsyncCommand to README.md

A new command, `CancelAsyncCommand`, has been added to the list of available commands in the README.md file. This command is intended to cancel a chat prompt, providing additional functionality to the application.